### PR TITLE
Update NegotiateLanguage Middleware to Prevent Open Redirection

### DIFF
--- a/src/Middleware/NegotiateLanguage.php
+++ b/src/Middleware/NegotiateLanguage.php
@@ -42,7 +42,7 @@ class NegotiateLanguage
             $negotiator = $this->i18n->getConfig('negotiator');
             $locale = app($negotiator)->preferredLocale($request);
 
-            return redirect($this->i18n->url($request->getRequestUri(), $locale));
+            return redirect($this->i18n->url($request->fullUrl(), $locale));
         }
 
         return $next($request);


### PR DESCRIPTION
Change `getRequestUri()` to `fullUrl()` in NegotiateLanguage Middleware to prevent open redirection.