### PR TITLE
Add Option to Disable Cache on LoadLocale

### DIFF
--- a/config/i18n.php
+++ b/config/i18n.php
@@ -97,5 +97,15 @@ return [
     | translation table name.
     |
     */
-    'translation_table_suffix' => 'translations'
+    'translation_table_suffix' => 'translations',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable Store to the cache
+    |--------------------------------------------------------------------------
+    |
+    | Toggle store locale to the cache
+    |
+    */
+    'enable_cache' => env('I18N_ENABLE_CACHE', true),
 ];

--- a/src/I18nService.php
+++ b/src/I18nService.php
@@ -180,6 +180,10 @@ class I18nService
         $duration = $this->getConfig('cache_duration', 86400);
         $ttl = Carbon::now()->addSeconds($duration);
 
+        if (!$this->getConfig('enable_cache')) {
+            return app(RepositoryManager::class)->collect();
+        }
+
         return \Cache::remember($cacheKey, $ttl, function () {
             return app(RepositoryManager::class)->collect();
         });

--- a/tests/I18nServiceTests.php
+++ b/tests/I18nServiceTests.php
@@ -152,6 +152,16 @@ class I18nServiceTests extends TestCase
     }
 
     /** @test */
+    public function it_does_not_cache_locale()
+    {
+        $this->app['config']->set('i18n.enable_cache', 'false');
+        $cacheKey = 'laravel-i18n-locale-'.$this->service->getConfig('driver');
+        $collection = $this->invokeMethod($this->service, 'loadLocale');
+
+        $this->assertEquals(null, \Cache::get($cacheKey));
+    }
+
+    /** @test */
     public function it_can_determine_the_routed_locale_based_on_the_given_request_object()
     {
         $this->request->shouldReceive('segment')

--- a/tests/I18nServiceTests.php
+++ b/tests/I18nServiceTests.php
@@ -152,11 +152,25 @@ class I18nServiceTests extends TestCase
     }
 
     /** @test */
+    public function it_caches_locale()
+    {
+        $cacheKey = 'laravel-i18n-locale-'.$this->service->getConfig('driver');
+        \Cache::forget($cacheKey);
+        $collection = $this->invokeMethod($this->service, 'loadLocale');
+
+        $this->assertEquals($collection->get('en'), \Cache::get($cacheKey)->get('en'));
+        $this->assertEquals($collection->get('es'), \Cache::get($cacheKey)->get('es'));
+        $this->assertEquals($collection->get('de'), \Cache::get($cacheKey)->get('de'));
+    }
+
+    /** @test */
     public function it_does_not_cache_locale()
     {
-        $this->app['config']->set('i18n.enable_cache', 'false');
+        $this->app['config']->set('i18n.enable_cache', false);
+        $this->invokeMethod($this->service, 'loadConfig');
         $cacheKey = 'laravel-i18n-locale-'.$this->service->getConfig('driver');
-        $collection = $this->invokeMethod($this->service, 'loadLocale');
+        \Cache::forget($cacheKey);
+        $this->invokeMethod($this->service, 'loadLocale');
 
         $this->assertEquals(null, \Cache::get($cacheKey));
     }


### PR DESCRIPTION
Add Option to Disable Cache on LoadLocale:
- added `enable_cache` to config.
- edited loadLocale() function.