### PR TITLE
Add Support For Laravel 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,101 +2,93 @@ name: Build
 
 on:
   push:
-    paths-ignore: ['*.md']
+    paths-ignore: ["*.md"]
   pull_request:
-    paths-ignore: ['*.md']
-    branches: [ master, main ]
+    paths-ignore: ["*.md"]
+    branches: [master, main]
 
 jobs:
   analysis:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: laravel-i18n-analysis
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --prefer-dist
       - name: Run phpstan analysis
         run: composer phpstan-analysis
       - name: Run phpmd analysis
         run: composer phpmd-analysis
-      - name: Run phpcpd analysis
-        run: vendor/bin/phpcpd --min-lines=3 --min-tokens=36 src/
   test:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.4, 8.0, 8.1 ]
+        php: [8.0, 8.1, 8.2]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: laravel-i18n-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
-      - name: Run PHPUnit tests and generate code coverage
+      - name: Run PHPUnit tests
         run: vendor/bin/phpunit
   test-coverage:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.2 ]
+        php: [8.3]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: laravel-i18n-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run PHPUnit tests and generate code coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore: ["*.md"]
   pull_request:
     paths-ignore: ["*.md"]
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   analysis:
@@ -21,8 +21,12 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: laravel-i18n-analysis
         with:
@@ -52,8 +56,12 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: laravel-i18n-test
         with:
@@ -80,8 +88,12 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: laravel-i18n-test
         with:

--- a/composer.json
+++ b/composer.json
@@ -27,23 +27,21 @@
         "source": "https://github.com/richan-fongdasen/laravel-i18n"
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/database": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "nesbot/carbon": "^2.16"
+        "php": "^8.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "nesbot/carbon": "^2.16|^3.0"
     },
     "require-dev": {
         "ekino/phpstan-banned-code": "^1.0",
-        "fakerphp/faker": "^1.19|^1.9.1",
-        "mockery/mockery": "^1.5|^1.4.4",
-        "nunomaduro/larastan": "^1.0|^2.0",
-        "orchestra/database": "^6.0|dev-master",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "fakerphp/faker": "^1.9",
+        "mockery/mockery": "^1.4",
+        "larastan/larastan": "^1.0|^2.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|9.x-dev",
         "phpmd/phpmd": "^2.11",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.0",
-        "phpunit/phpunit": "^9.5",
-        "sebastian/phpcpd": "^6.0"
+        "phpunit/phpunit": "^9.5|^10.0|^11.0"
     },
     "config": {
         "sort-packages": true
@@ -73,8 +71,7 @@
         "analyse": [
             "composer check-syntax",
             "composer phpstan-analysis",
-            "composer phpmd-analysis",
-            "vendor/bin/phpcpd --min-lines=3 --min-tokens=36 src/"
+            "composer phpmd-analysis"
         ],
         "check-syntax": [
             "! find src -type f -name \"*.php\" -exec php -l {} \\; |  grep -v 'No syntax errors'",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/ekino/phpstan-banned-code/extension.neon

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Laravel I18n Test Suite">
       <directory suffix="Test.php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Build](https://github.com/richan-fongdasen/laravel-i18n/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/richan-fongdasen/laravel-i18n/actions/workflows/main.yml) 
+[![Build](https://github.com/richan-fongdasen/laravel-i18n/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/richan-fongdasen/laravel-i18n/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/richan-fongdasen/laravel-i18n/branch/master/graph/badge.svg)](https://codecov.io/gh/richan-fongdasen/laravel-i18n)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/richan-fongdasen/laravel-i18n/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/richan-fongdasen/laravel-i18n/?branch=master)
 [![StyleCI Analysis Status](https://github.styleci.io/repos/135787392/shield?branch=master)](https://github.styleci.io/repos/135787392)
@@ -12,36 +12,38 @@
 
 ## Synopsis
 
-This package provides easy ways to setup database translation and route localization. 
+This package provides easy ways to setup database translation and route localization.
 
 ## Table of contents
 
-* [Setup](#setup)
-* [Publish package assets](#publish-package-assets)
-* [Configuration](#configuration)
-* [Documentation](#documentation)
-* [Credits](#credits)
-* [License](#license)
+- [Setup](#setup)
+- [Publish package assets](#publish-package-assets)
+- [Configuration](#configuration)
+- [Documentation](#documentation)
+- [Credits](#credits)
+- [License](#license)
 
 ## Setup
 
 Install the package via Composer :
+
 ```sh
 $ composer require richan-fongdasen/laravel-i18n
 ```
 
 ## Publish package assets
 
-Publish the package asset files using this ``php artisan`` command
+Publish the package asset files using this `php artisan` command
 
 ```sh
 $ php artisan vendor:publish --provider="RichanFongdasen\I18n\ServiceProvider"
 ```
 
 The command above would create three new files in your application, such as:
-* New configuration file ``/config/i18n.php``
-* New database migration ``/database/migrations/0000_00_00_000000_create_languages_table.php``
-* New languages json file ``/storage/i18n/languages.json``
+
+- New configuration file `/config/i18n.php`
+- New database migration `/database/migrations/0000_00_00_000000_create_languages_table.php`
+- New languages json file `/storage/i18n/languages.json`
 
 ## Configuration
 
@@ -134,7 +136,7 @@ return [
     | e.g: http://my-application.app/en/home
     |
     */
-   
+
     'locale_url_segment' => 1,
 
     /*
@@ -169,9 +171,9 @@ Please check the documentation here [https://laravel-i18n.richan.id/](https://la
 
 ## Credits
 
-* [mcamara/laravel-localization](https://github.com/mcamara/laravel-localization) - Route localization concepts in this repository was inspired by this package.
-* [Wico Chandra](https://github.com/wicochandra) - Database translation concepts in this repository was inspired by his `Model Translation` concept.
-* [dimsav/laravel-translatable](https://github.com/dimsav/laravel-translatable) - Some of database translation concepts in this repository was inspired by this package.
+- [mcamara/laravel-localization](https://github.com/mcamara/laravel-localization) - Route localization concepts in this repository was inspired by this package.
+- [Wico Chandra](https://github.com/wicochandra) - Database translation concepts in this repository was inspired by his `Model Translation` concept.
+- [dimsav/laravel-translatable](https://github.com/dimsav/laravel-translatable) - Some of database translation concepts in this repository was inspired by this package.
 
 ## License
 

--- a/src/Contracts/TranslatableModel.php
+++ b/src/Contracts/TranslatableModel.php
@@ -102,7 +102,7 @@ interface TranslatableModel
      *
      * @param Locale|null $locale
      *
-     *@throws \ErrorException
+     * @throws \ErrorException
      *
      * @return Model
      */

--- a/src/Eloquent/Models/Language.php
+++ b/src/Eloquent/Models/Language.php
@@ -21,7 +21,7 @@ class Language extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',

--- a/src/Middleware/NegotiateLanguage.php
+++ b/src/Middleware/NegotiateLanguage.php
@@ -30,8 +30,8 @@ class NegotiateLanguage
     /**
      * Handle an incoming request.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @param \Illuminate\Http\Request                                                                          $request
+     * @param \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse) $next
      *
      * @throws ErrorException
      *

--- a/src/Middleware/TranslatesAPI.php
+++ b/src/Middleware/TranslatesAPI.php
@@ -29,8 +29,8 @@ class TranslatesAPI
     /**
      * Handle an incoming request.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @param \Illuminate\Http\Request                                                                          $request
+     * @param \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse) $next
      *
      * @throws \ErrorException
      *

--- a/tests/DatabaseRepositoryTest.php
+++ b/tests/DatabaseRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\I18n\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Support\Facades\DB;
 use RichanFongdasen\I18n\Contracts\LocaleRepository;
 use RichanFongdasen\I18n\DatabaseRepository;
@@ -54,7 +55,7 @@ class DatabaseRepositoryTest extends TestCase
         $this->repository = new DatabaseRepository;
     }
 
-    /** @test */
+    #[Test]
     public function it_can_resolve_the_abstract_interface_as_json_repository()
     {
         $repository = app(LocaleRepository::class);
@@ -62,7 +63,7 @@ class DatabaseRepositoryTest extends TestCase
         self::assertInstanceOf(DatabaseRepository::class, $repository);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_load_all_the_locale_from_the_datasource()
     {
         $collection = $this->repository->all();

--- a/tests/Eloquent/Concerns/TranslatableTest.php
+++ b/tests/Eloquent/Concerns/TranslatableTest.php
@@ -2,13 +2,14 @@
 
 namespace RichanFongdasen\I18n\Tests\Eloquent\Concerns;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Facade\I18n;
 use RichanFongdasen\I18n\Tests\Supports\Models\Product;
 use RichanFongdasen\I18n\Tests\TestCase;
 
 class TranslatableTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_can_create_new_translation_model_based_on_the_given_locale()
     {
         $product = new Product();
@@ -20,7 +21,7 @@ class TranslatableTest extends TestCase
         $this->assertEquals('es', $translation->locale);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_filled_with_complete_translation_attributes()
     {
         $product = new Product();
@@ -56,7 +57,7 @@ class TranslatableTest extends TestCase
         $product->translateTo('id');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_filled_with_incomplete_translation_attributes()
     {
         $product = new Product();
@@ -83,7 +84,7 @@ class TranslatableTest extends TestCase
         $this->assertEquals('English description', $product->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_generate_join_attributes_correctly()
     {
         $product = new Product();
@@ -98,7 +99,7 @@ class TranslatableTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_all_of_the_translatable_attributes()
     {
         $product = new Product();

--- a/tests/Features/GettingTranslatableAttributesTest.php
+++ b/tests/Features/GettingTranslatableAttributesTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Query\JoinClause;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Facade\I18n;
 use RichanFongdasen\I18n\Tests\Supports\Concerns\SeedsRequiredDatabase;
 use RichanFongdasen\I18n\Tests\Supports\Models\Product;
@@ -28,7 +29,7 @@ class GettingTranslatableAttributesTest extends TestCase
         $this->seedDatabase();
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_translation_attribute_correctly()
     {
         App::setLocale('es');
@@ -44,7 +45,7 @@ class GettingTranslatableAttributesTest extends TestCase
         self::assertEquals($expected->description, $product->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_translation_value_correctly()
     {
         App::setLocale('de');
@@ -60,7 +61,7 @@ class GettingTranslatableAttributesTest extends TestCase
         self::assertEquals($expected->description, $product->translation()->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_fallback_value_when_the_translated_value_is_not_available()
     {
         App::setLocale('es');
@@ -79,7 +80,7 @@ class GettingTranslatableAttributesTest extends TestCase
         self::assertEquals($expected->description, $product->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_join_the_translation_table()
     {
         $join = data_get(Product::joinTranslation()->getQuery()->joins, '0');
@@ -96,7 +97,7 @@ class GettingTranslatableAttributesTest extends TestCase
         self::assertEquals($expected, Product::joinTranslation()->getQuery()->columns);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_translate_the_model_based_on_the_given_locale_key()
     {
         $product = Product::find(9)->translateTo('de');
@@ -110,7 +111,7 @@ class GettingTranslatableAttributesTest extends TestCase
         self::assertEquals($expected->description, $product->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_all_translatable_attribute_values()
     {
         $product = Product::create([
@@ -141,7 +142,7 @@ class GettingTranslatableAttributesTest extends TestCase
         self::assertEquals($expected, $product->getAllTranslationValues());
     }
 
-    /** @test */
+    #[Test]
     public function it_will_merge_the_translation_attributes_on_array_serialization()
     {
         $product = Product::find(8)
@@ -165,7 +166,7 @@ class GettingTranslatableAttributesTest extends TestCase
         self::assertEquals($expected, $product->toArray());
     }
 
-    /** @test */
+    #[Test]
     public function eloquent_collections_are_translatable()
     {
         $products = Product::where('product_category_id', 1)->get();

--- a/tests/Features/SavingTranslatableAttributesTest.php
+++ b/tests/Features/SavingTranslatableAttributesTest.php
@@ -3,6 +3,7 @@
 namespace RichanFongdasen\I18n\Tests\Features;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Facade\I18n;
 use RichanFongdasen\I18n\Tests\Supports\Models\Product;
 use RichanFongdasen\I18n\Tests\TestCase;
@@ -11,7 +12,7 @@ class SavingTranslatableAttributesTest extends TestCase
 {
     use DatabaseMigrations;
 
-    /** @test */
+    #[Test]
     public function it_can_save_the_translation_by_specifying_translatable_attribute_values_one_by_one()
     {
         $product = Product::create([
@@ -42,7 +43,7 @@ class SavingTranslatableAttributesTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_filled_and_saved_with_complete_translation_attributes()
     {
         $product = new Product();
@@ -71,7 +72,7 @@ class SavingTranslatableAttributesTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_filled_with_incomplete_translation_attributes()
     {
         $product = new Product();
@@ -104,7 +105,7 @@ class SavingTranslatableAttributesTest extends TestCase
         self::assertEquals('English description', $product->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_filled_with_only_default_translation_attributes()
     {
         $product = new Product();
@@ -128,7 +129,7 @@ class SavingTranslatableAttributesTest extends TestCase
         self::assertEquals(null, $product->translation(I18n::getLocale('de'))->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_update_all_translation_records_with_mass_assignment()
     {
         $original = Product::create([
@@ -167,7 +168,7 @@ class SavingTranslatableAttributesTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_update_all_translation_records_with_single_assignment()
     {
         $original = new Product();
@@ -205,7 +206,7 @@ class SavingTranslatableAttributesTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_filled_and_saved_with_alternative_data_structure()
     {
         $product = new Product();
@@ -236,7 +237,7 @@ class SavingTranslatableAttributesTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_filled_and_updated_with_alternative_data_structure()
     {
         $original = Product::create([

--- a/tests/I18nRouterTest.php
+++ b/tests/I18nRouterTest.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\I18n\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use RichanFongdasen\I18n\I18nRouter;
@@ -44,7 +45,7 @@ class I18nRouterTest extends TestCase
      * @return void
      * @throws \ErrorException
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,7 +57,7 @@ class I18nRouterTest extends TestCase
         $this->locale = $this->service->getDefaultLocale();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_identify_and_returns_the_respective_locale_instance()
     {
         $this->request->shouldReceive('segment')->withArgs([1])->andReturn('es');
@@ -68,7 +69,7 @@ class I18nRouterTest extends TestCase
         self::assertEquals('es', App::getLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_on_empty_locale_key_segment()
     {
         $this->request->shouldReceive('segment')->withArgs([1])->andReturn('');
@@ -79,7 +80,7 @@ class I18nRouterTest extends TestCase
         self::assertEquals('en', App::getLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_on_unidentified_locale_key_segment()
     {
         $this->request->shouldReceive('segment')->withArgs([1])->andReturn('unknown');
@@ -90,7 +91,7 @@ class I18nRouterTest extends TestCase
         self::assertEquals('en', App::getLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_returns_the_url_prefix_correctly()
     {
         $this->request->shouldReceive('segment')->withArgs([1])->andReturn('de');
@@ -98,7 +99,7 @@ class I18nRouterTest extends TestCase
         self::assertEquals('de', $this->router->getPrefix());
     }
 
-    /** @test */
+    #[Test]
     public function it_raises_exception_on_generating_url_with_an_invalid_locale()
     {
         $this->expectException(\ErrorException::class);
@@ -106,7 +107,7 @@ class I18nRouterTest extends TestCase
         $this->router->url('/about-us/company-overview', 'ar');
     }
 
-    /** @test */
+    #[Test]
     public function it_generate_correct_url_based_on_the_given_locale()
     {
         $expected = '/de/about-us/company-overview';
@@ -115,7 +116,7 @@ class I18nRouterTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_generate_correct_url_based_on_the_routed_locale()
     {
         $this->request->shouldReceive('segment')
@@ -129,7 +130,7 @@ class I18nRouterTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_generate_correct_url_based_on_the_default_locale()
     {
         $this->request->shouldReceive('segment')

--- a/tests/I18nServiceTest.php
+++ b/tests/I18nServiceTest.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\I18n\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Contracts\LocaleRepository;
 use RichanFongdasen\I18n\I18nService;
 use RichanFongdasen\I18n\Locale;
@@ -45,7 +46,7 @@ class I18nServiceTest extends TestCase
         $this->service = new I18nService($this->repository, $this->request);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_all_locale_collection()
     {
         $this->repository->shouldReceive('all')->andReturn(new Collection([1, 2, 3]));
@@ -55,7 +56,7 @@ class I18nServiceTest extends TestCase
         self::assertEquals(3, $actual->count());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_the_default_locale()
     {
         $expected = new Locale('English', 'en', 'US');
@@ -66,7 +67,7 @@ class I18nServiceTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_the_locale_based_on_the_given_language_key()
     {
         $expected = new Locale('English', 'en', 'US');
@@ -77,7 +78,7 @@ class I18nServiceTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_the_locale_keys_based_on_the_given_attribute_name()
     {
         $expected = ['en', 'es', 'de'];
@@ -88,7 +89,7 @@ class I18nServiceTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_guess_the_translation_table_name_for_a_model()
     {
         self::assertEquals('news_translations', $this->service->guessTranslationTable('News'));

--- a/tests/JsonRepositoryTest.php
+++ b/tests/JsonRepositoryTest.php
@@ -2,13 +2,14 @@
 
 namespace RichanFongdasen\I18n\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Contracts\LocaleRepository;
 use RichanFongdasen\I18n\JsonRepository;
 use RichanFongdasen\I18n\Locale;
 
 class JsonRepositoryTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_can_resolve_the_abstract_interface_as_json_repository()
     {
         $repository = app(LocaleRepository::class);
@@ -16,7 +17,7 @@ class JsonRepositoryTest extends TestCase
         self::assertInstanceOf(JsonRepository::class, $repository);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_load_all_the_locale_from_the_datasource()
     {
         $collection = (new JsonRepository)->all();
@@ -43,7 +44,7 @@ class JsonRepositoryTest extends TestCase
         self::assertEquals('de-DE', $germany->ietfCode);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_empty_collection_on_empty_datasource()
     {
         $this->expectException(\ErrorException::class);

--- a/tests/LocaleRepositoryTest.php
+++ b/tests/LocaleRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\I18n\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Contracts\LocaleRepository;
 use RichanFongdasen\I18n\JsonRepository;
 use RichanFongdasen\I18n\Locale;
@@ -27,7 +28,7 @@ class LocaleRepositoryTest extends TestCase
         $this->repository = app(LocaleRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_return_all_the_registered_locale()
     {
         $collection = $this->repository->all();
@@ -38,8 +39,8 @@ class LocaleRepositoryTest extends TestCase
             self::assertInstanceOf(Locale::class, $locale);
         }
     }
-    
-    /** @test */
+
+    #[Test]
     public function it_can_return_fallback_language_as_the_default_language()
     {
         config([
@@ -54,7 +55,7 @@ class LocaleRepositoryTest extends TestCase
         self::assertEquals('de-DE', $locale->ietfCode);
     }
 
-    /** @test */
+    #[Test]
     public function it_raises_exception_on_invalid_fallback_language()
     {
         $this->expectException(\ErrorException::class);
@@ -65,7 +66,7 @@ class LocaleRepositoryTest extends TestCase
         new JsonRepository;
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_locale_based_on_the_given_key()
     {
         $locale = $this->repository->get('es');
@@ -76,7 +77,7 @@ class LocaleRepositoryTest extends TestCase
         self::assertEquals('es-ES', $locale->ietfCode);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_exact_locale_object_when_retrieved_using_different_key()
     {
         $locale1 = $this->repository->get('en');
@@ -85,7 +86,7 @@ class LocaleRepositoryTest extends TestCase
         self::assertEquals($locale1, $locale2);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_when_retrieving_locale_using_invalid_key()
     {
         $locale = $this->repository->get('id-ID');
@@ -93,7 +94,7 @@ class LocaleRepositoryTest extends TestCase
         self::assertNull($locale);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_all_locale_keys_grouped_by_language()
     {
         $expected = ['en', 'es', 'de'];
@@ -103,7 +104,7 @@ class LocaleRepositoryTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_all_locale_keys_grouped_by_ietf_code()
     {
         $expected = ['en-US', 'es-ES', 'de-DE'];
@@ -113,7 +114,7 @@ class LocaleRepositoryTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_when_retrieving_all_locale_keys_grouped_by_invalid_key()
     {
         $actual = $this->repository->getKeys('title');

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -2,11 +2,12 @@
 
 namespace RichanFongdasen\I18n\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Locale;
 
 class LocaleTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function all_the_class_properties_are_accessible_read_only()
     {
         $locale = new Locale('english', 'EN', 'us');
@@ -17,7 +18,7 @@ class LocaleTest extends TestCase
         self::assertEquals('en-US', $locale->ietfCode);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_locale_key_value()
     {
         config(['i18n.language_key' => 'ietfCode']);

--- a/tests/Middleware/NegotiateLanguageTest.php
+++ b/tests/Middleware/NegotiateLanguageTest.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\I18n\Tests\Middleware;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Contracts\LocaleRepository;
 use RichanFongdasen\I18n\I18nService;
 use RichanFongdasen\I18n\Middleware\NegotiateLanguage;
@@ -37,7 +38,7 @@ class NegotiateLanguageTest extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -45,8 +46,8 @@ class NegotiateLanguageTest extends TestCase
         $this->service = new I18nService(app(LocaleRepository::class), $this->request);
         $this->middleware = new NegotiateLanguage($this->service);
     }
-    
-    /** @test */
+
+    #[Test]
     public function it_will_raise_exception_on_invalid_negotiator_defined_in_config()
     {
         $closure = function (Request $request) {
@@ -63,7 +64,7 @@ class NegotiateLanguageTest extends TestCase
         $this->middleware->handle($this->request, $closure);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_pass_the_request_if_the_request_has_locale_prefix_in_its_url()
     {
         $closure = function (Request $request) {
@@ -80,7 +81,7 @@ class NegotiateLanguageTest extends TestCase
         $this->assertEquals('Hurray!!', $actual);
     }
 
-    /** @test */
+    #[Test]
     public function redirect_to_english_localized_url_if_the_request_has_no_locale_prefix_in_its_url()
     {
         $closure = function (Request $request) {
@@ -107,7 +108,7 @@ class NegotiateLanguageTest extends TestCase
         $this->assertEquals($expected, $response->getTargetUrl());
     }
 
-    /** @test */
+    #[Test]
     public function redirect_to_spanish_localized_url_if_the_request_has_no_locale_prefix_in_its_url()
     {
         $closure = function (Request $request) {

--- a/tests/Middleware/TranslatesAPITest.php
+++ b/tests/Middleware/TranslatesAPITest.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\I18n\Tests\Middleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Contracts\LocaleRepository;
 use RichanFongdasen\I18n\I18nService;
 use RichanFongdasen\I18n\Middleware\TranslatesAPI;
@@ -37,7 +38,7 @@ class TranslatesAPITest extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -49,7 +50,7 @@ class TranslatesAPITest extends TestCase
         $this->middleware = new TranslatesAPI($this->service);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_favor_default_app_language_when_there_was_no_language_parameter_in_api_query()
     {
         $closure = function (Request $request) {
@@ -62,7 +63,7 @@ class TranslatesAPITest extends TestCase
         self::assertEquals('en', App::getLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_will_favor_default_app_language_on_invalid_language_query_parameter()
     {
         $closure = function (Request $request) {
@@ -75,7 +76,7 @@ class TranslatesAPITest extends TestCase
         self::assertEquals('en', App::getLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_will_switch_the_app_language_based_on_the_requested_language_query_parameter()
     {
         $closure = function (Request $request) {

--- a/tests/Negotiators/BrowserNegotiatorTest.php
+++ b/tests/Negotiators/BrowserNegotiatorTest.php
@@ -3,6 +3,7 @@
 namespace RichanFongdasen\I18n\Tests\Negotiators;
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\Contracts\LocaleRepository;
 use RichanFongdasen\I18n\I18nService;
 use RichanFongdasen\I18n\Locale;
@@ -30,7 +31,7 @@ class BrowserNegotiatorTest extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -40,7 +41,7 @@ class BrowserNegotiatorTest extends TestCase
         $this->negotiator = new BrowserNegotiator($service);
     }
 
-    /** @test */
+    #[Test]
     public function it_return_english_locale_based_on_browsers_primary_language_code()
     {
         $this->request->shouldReceive('getLanguages')
@@ -53,7 +54,7 @@ class BrowserNegotiatorTest extends TestCase
         $this->assertEquals('en-US', $locale->ietfCode);
     }
 
-    /** @test */
+    #[Test]
     public function it_return_english_locale_based_on_browsers_primary_ietf_code()
     {
         $this->request->shouldReceive('getLanguages')
@@ -66,7 +67,7 @@ class BrowserNegotiatorTest extends TestCase
         $this->assertEquals('en-US', $locale->ietfCode);
     }
 
-    /** @test */
+    #[Test]
     public function it_return_spanish_locale_based_on_browsers_secondary_language_code()
     {
         $this->request->shouldReceive('getLanguages')
@@ -79,7 +80,7 @@ class BrowserNegotiatorTest extends TestCase
         $this->assertEquals('es-ES', $locale->ietfCode);
     }
 
-    /** @test */
+    #[Test]
     public function it_return_spanish_locale_based_on_browsers_secondary_ietf_code()
     {
         $this->request->shouldReceive('getLanguages')
@@ -92,7 +93,7 @@ class BrowserNegotiatorTest extends TestCase
         $this->assertEquals('es-ES', $locale->ietfCode);
     }
 
-    /** @test */
+    #[Test]
     public function it_return_english_locale_as_fallback_locale()
     {
         $this->request->shouldReceive('getLanguages')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,7 +57,7 @@ abstract class TestCase extends BaseTest
 
         return [
             \Illuminate\Cache\CacheServiceProvider::class,
-            \Orchestra\Database\ConsoleServiceProvider::class,
+            // \Orchestra\Database\ConsoleServiceProvider::class,
             \RichanFongdasen\I18n\ServiceProvider::class,
         ];
     }
@@ -114,7 +114,7 @@ abstract class TestCase extends BaseTest
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\I18n\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\I18n\I18nService;
 use RichanFongdasen\I18n\Locale;
 use RichanFongdasen\I18n\UrlGenerator;
@@ -35,7 +36,7 @@ class UrlGeneratorTest extends TestCase
      * @return void
      * @throws \ErrorException
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +45,7 @@ class UrlGeneratorTest extends TestCase
         $this->locale = $this->service->getDefaultLocale();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_parse_complex_url()
     {
         $this->urlGenerator->set('https://usr:psw@test.de:81/my/file.php?a=b&b[]=2&b[]=3#myFragment');
@@ -59,7 +60,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('#myFragment', $this->getPropertyValue($this->urlGenerator, 'fragment'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_parse_schemaless_url()
     {
         $this->urlGenerator->set('//:pass@test.de:82/my/file.php#myFragment');
@@ -74,7 +75,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('#myFragment', $this->getPropertyValue($this->urlGenerator, 'fragment'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_parse_hostless_url()
     {
         $this->urlGenerator->set('/my/file.php?a=b&b[]=2&b[]=3#myFragment');
@@ -89,7 +90,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('#myFragment', $this->getPropertyValue($this->urlGenerator, 'fragment'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_localize_any_url_based_on_the_given_locale_object()
     {
         $actual = $this->urlGenerator->set('/about/company-overview')->localize($this->locale)->get();
@@ -102,14 +103,14 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('//usr:psw@test.de:81/en/my/file.php?a=b&b[]=2&b[]=3#myFragment', $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_default_value_on_extracting_empty_url()
     {
         $actual = $this->invokeMethod($this->urlGenerator, 'extract', [[], 'scheme', '//']);
         $this->assertEquals('//', $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_localize_url_which_already_contain_locale_keyword()
     {
         $english = $this->service->getLocale('en');
@@ -131,7 +132,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals($spanishUrl, $this->urlGenerator->localize($spanish)->get());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_localize_url_which_already_contain_locale_keyword_at_custom_segment_index()
     {
         config(['i18n.locale_url_segment' => 3]);


### PR DESCRIPTION
* Add support for Laravel 11
* Add support for PHP 8.3
* Drop support for PHP 7.4
* Update package dependencies
* Update PHP Unit configuration
* Update the test codes from using doc-comment metadata to use PHP 8 attribute
* Update github actions workflow's configuration
